### PR TITLE
gunicorn to forward access log to STDOUT

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,3 +2,4 @@ import os
 
 
 bind = os.environ.get('GUNICORN_BIND', '0.0.0.0:5000')
+accesslog = '-'


### PR DESCRIPTION
## Docker
Gunicorn to forward access log to STDOUT

## Misc
Allows logs to appear in docker log